### PR TITLE
Use deterministic initial answers from initial pool

### DIFF
--- a/run_mmlu.py
+++ b/run_mmlu.py
@@ -11,7 +11,7 @@ import random
 import argparse
 from datetime import datetime
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Tuple, Dict, Any
 
 import yaml
 from datasets import load_dataset
@@ -23,6 +23,12 @@ from src.prompt_logger import PromptLogger
 
 LABELS: List[str] = ["A", "B", "C", "D", "E", "F"]  # 最大 6 択
 SEED = 42  # 再現性のための乱数シード
+INITIAL_POOL_PATH = (
+    Path(__file__).resolve().parent
+    / "Initial_answer"
+    / "initial_pool_20251219_152013"
+    / "initial_pool.jsonl"
+)
 
 
 # ---------- ユーティリティ ---------- #
@@ -59,6 +65,33 @@ def choose_adversary_target(gold_label: str | None) -> str:
     return random.choice(pool)
 
 
+def load_initial_pool(pool_path: Path) -> Tuple[Dict[int, Dict[str, Any]], Dict[str, Dict[str, Any]]]:
+    pool_by_index: Dict[int, Dict[str, Any]] = {}
+    pool_by_question: Dict[str, Dict[str, Any]] = {}
+    if not pool_path.exists():
+        print(f"[Warn] initial pool file not found: {pool_path}")
+        return pool_by_index, pool_by_question
+
+    with open(pool_path, "r", encoding="utf-8") as f:
+        for line_no, line in enumerate(f, start=1):
+            if not line.strip():
+                continue
+            entry = json.loads(line)
+            index_in_split = entry.get("index_in_split")
+            question = entry.get("question")
+            if isinstance(index_in_split, int):
+                if index_in_split not in pool_by_index:
+                    pool_by_index[index_in_split] = entry
+                else:
+                    print(f"[Warn] Duplicate index_in_split at line {line_no}: {index_in_split}")
+            if isinstance(question, str) and question:
+                if question not in pool_by_question:
+                    pool_by_question[question] = entry
+                else:
+                    print(f"[Warn] Duplicate question at line {line_no}")
+    return pool_by_index, pool_by_question
+
+
 # ---------- メイン ---------- #
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run MMLU debate evaluation")
@@ -74,6 +107,7 @@ def main() -> None:
     random.seed(SEED)
 
     base_cfg = load_config()
+    pool_by_index, pool_by_question = load_initial_pool(INITIAL_POOL_PATH)
 
     # 実行フォルダ作成
     run_ts = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -133,10 +167,14 @@ def main() -> None:
         # ---- トピック & 正解 ----
         topic = format_topic(ex["question"], ex["choices"])
         gold_label = idx_to_label(ex["answer"])
+        pool_entry = pool_by_index.get(ds_idx) or pool_by_question.get(ex["question"])
+        if not pool_entry:
+            print(f"[Warn] No initial pool entry found for idx={ds_idx}")
 
         # ---- config の複製と動的設定 ----
         cfg = copy.deepcopy(base_cfg)
         cfg["discussion"]["topic"] = topic
+        cfg["initial_pool_entry"] = pool_entry
 
         # Adversary のターゲット決定
         current_adv_target = None

--- a/src/agent.py
+++ b/src/agent.py
@@ -56,6 +56,10 @@ class Agent:
         )
         return usage
 
+    def set_initial_answer(self, *, answer: str, reason: str) -> None:
+        self.initial_answer = {"answer": answer, "reason": reason}
+        self.initial_answer_str = f"answer: {answer}, reason: {reason}"
+
     # ──────────────────── 最終回答 ──────────────────── #
     def generate_final_answer(self, topic: str, debate_history: str, latest_thoughts: str, max_turn: int, peer_names: Sequence[str]) -> Tuple[dict[str, str], Dict[str, int]]:
         if self.role == "adversary" and self.adversary_target:

--- a/src/manager.py
+++ b/src/manager.py
@@ -125,10 +125,59 @@ class DiscussionManager:
                     print(f"[System] Agent {ag.name} is set as NORMAL.")
 
         # 1) 初回回答
-        for ag in self.agents:
-            usage = ag.generate_initial_answer(self.topic, self.max_turns, [p.name for p in self.agents if p is not ag])
-            self._accumulate_token_usage(usage)
-            print(f"[Init] {ag.name} → {ag.initial_answer_str}")
+        pool_entry = self.config.get("initial_pool_entry")
+        if pool_entry:
+            picked = pool_entry.get("picked") or []
+            correct_pool = [p for p in picked if p.get("label") == "correct"]
+            wrong_pool = [p for p in picked if p.get("label") == "wrong"]
+            correct_idx = 0
+            wrong_idx = 0
+            for ag in self.agents:
+                selected: Dict[str, Any] | None = None
+                if ag.role == "adversary":
+                    if wrong_idx < len(wrong_pool):
+                        selected = wrong_pool[wrong_idx]
+                        wrong_idx += 1
+                    elif correct_idx < len(correct_pool):
+                        print(
+                            f"[Warn] No wrong answers left for adversary {ag.name}; "
+                            "falling back to correct pool."
+                        )
+                        selected = correct_pool[correct_idx]
+                        correct_idx += 1
+                else:
+                    if correct_idx < len(correct_pool):
+                        selected = correct_pool[correct_idx]
+                        correct_idx += 1
+                    elif wrong_idx < len(wrong_pool):
+                        print(
+                            f"[Warn] No correct answers left for agent {ag.name}; "
+                            "falling back to wrong pool."
+                        )
+                        selected = wrong_pool[wrong_idx]
+                        wrong_idx += 1
+
+                if not selected:
+                    print(
+                        f"[Warn] No initial answers available for agent {ag.name}; "
+                        "falling back to empty answer."
+                    )
+                    selected = {"answer": "", "reason": ""}
+
+                ag.set_initial_answer(
+                    answer=str(selected.get("answer", "")),
+                    reason=str(selected.get("reason", "")),
+                )
+                print(f"[Init] {ag.name} → {ag.initial_answer_str}")
+        else:
+            for ag in self.agents:
+                usage = ag.generate_initial_answer(
+                    self.topic,
+                    self.max_turns,
+                    [p.name for p in self.agents if p is not ag],
+                )
+                self._accumulate_token_usage(usage)
+                print(f"[Init] {ag.name} → {ag.initial_answer_str}")
 
         # 2) 全初回回答を共有
         all_initial = "\n".join(


### PR DESCRIPTION
### Motivation
- Provide deterministic, reproducible initial answers for debates by consuming a pre-built initial-answer pool instead of always querying the LLM. 
- Allow tests and experiments to control which agent receives which initial answer (including adversaries) for repeatable evaluation runs. 
- Avoid unnecessary LLM calls when deterministic answers are available to reduce cost and variance.

### Description
- Add a pool loader and lookup in `run_mmlu.py` by introducing `INITIAL_POOL_PATH` and `load_initial_pool`, and attach the per-question entry to the per-run config as `cfg["initial_pool_entry"]`.
- Implement deterministic assignment logic in `src/manager.py` that consumes `initial_pool_entry["picked"]` by label and sequentially allocates `wrong` entries to adversaries and `correct` entries to normal agents with warnings and safe fallbacks; if no pool entry exists it falls back to the original `generate_initial_answer` flow.
- Add an `Agent.set_initial_answer` helper in `src/agent.py` so the manager can inject `initial_answer`/`initial_answer_str` without routing through the LLM, preserving existing token-usage behavior when the pool is not used.
- Improve robustness of pool loading by indexing entries by `index_in_split` and `question` with duplicate detection and warning logs, and ensure global `random` is seeded and used consistently.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69745ffdb09483328b5058fec54846ab)